### PR TITLE
MPL 2.0 projects can include Apache 2.0 dependencies

### DIFF
--- a/src/license.rs
+++ b/src/license.rs
@@ -99,7 +99,7 @@ impl License {
             BSD_3_Clause => [MIT, X11, BSD_3_Clause]
             Apache_2_0   => [MIT, X11, BSD_3_Clause, Apache_2_0]
             MPL_1_1      => [MIT, X11, BSD_3_Clause, MPL_1_1]
-            MPL_2_0      => [MIT, X11, BSD_3_Clause, MPL_2_0]
+            MPL_2_0      => [MIT, X11, BSD_3_Clause, Apache_2_0, MPL_2_0]
             LGPL_2_1Plus => [MIT, X11, BSD_3_Clause, MPL_2_0, LGPL_2_1Plus]
             LGPL_2_1     => [MIT, X11, BSD_3_Clause, MPL_2_0, LGPL_2_1Plus, LGPL_2_1]
             LGPL_3_0Plus => [MIT, X11, BSD_3_Clause, MPL_2_0, Apache_2_0, LGPL_2_1Plus, LGPL_3_0Plus]


### PR DESCRIPTION
See [the MPL 2.0 FAQ][1] and [a blog post by the lead author of the MPL 2.0][2]

Fixes #14

[1]: https://www.mozilla.org/en-US/MPL/2.0/FAQ/#mpl-bsd-and-apache
[2]: https://opensource.com/law/11/9/mpl-20-copyleft-and-license-compatibility