### PR TITLE
Change AGPL 1.0 to AGPL 3.0

### DIFF
--- a/src/license.rs
+++ b/src/license.rs
@@ -21,7 +21,7 @@ pub enum License {
     GPL_2_0Plus,
     GPL_3_0,
     GPL_3_0Plus,
-    AGPL_1_0,
+    AGPL_3_0,
     Custom(String),
     File(PathBuf),
     Multiple(Vec<License>),
@@ -108,7 +108,7 @@ impl License {
             GPL_2_0      => [MIT, X11, BSD_3_Clause, MPL_2_0, LGPL_2_1Plus, LGPL_2_1, GPL_2_0Plus, GPL_2_0]
             GPL_3_0Plus  => [MIT, X11, BSD_3_Clause, MPL_2_0, Apache_2_0, LGPL_2_1Plus, LGPL_2_1, GPL_2_0Plus, GPL_3_0Plus]
             GPL_3_0      => [MIT, X11, BSD_3_Clause, MPL_2_0, Apache_2_0, LGPL_2_1Plus, LGPL_2_1, GPL_2_0Plus, GPL_3_0Plus, GPL_3_0]
-            AGPL_1_0     => [MIT, X11, BSD_3_Clause, MPL_2_0, Apache_2_0, LGPL_2_1Plus, LGPL_2_1, GPL_2_0Plus, GPL_3_0Plus, GPL_3_0, AGPL_1_0]
+            AGPL_3_0     => [MIT, X11, BSD_3_Clause, MPL_2_0, Apache_2_0, LGPL_2_1Plus, LGPL_2_1, GPL_2_0Plus, GPL_3_0Plus, GPL_3_0, AGPL_3_0]
 
             // TODO: These are `unreachable!()`, can't figure out a nice way to allow this in the macro...
             Custom(_)    => [MIT]
@@ -139,7 +139,7 @@ impl FromStr for License {
             "GPL-2.0+"           => License::GPL_2_0Plus,
             "GPL-3.0"            => License::GPL_3_0,
             "GPL-3.0+"           => License::GPL_3_0Plus,
-            "AGPL-1.0"           => License::AGPL_1_0,
+            "AGPL-3.0"           => License::AGPL_3_0,
             s if s.contains('/') => {
                 let mut licenses = s.split('/')
                     .map(str::parse)
@@ -171,7 +171,7 @@ impl fmt::Display for License {
             License::GPL_2_0Plus   => write!(w, "GPL-2.0+"),
             License::GPL_3_0       => write!(w, "GPL-3.0"),
             License::GPL_3_0Plus   => write!(w, "GPL-3.0+"),
-            License::AGPL_1_0      => write!(w, "AGPL-1.0"),
+            License::AGPL_3_0      => write!(w, "AGPL-3.0"),
             License::Custom(ref s) => write!(w, "Custom({})", s),
             License::File(ref f)   => write!(w, "File({})", f.to_string_lossy()),
             License::Multiple(ref ls)   => {


### PR DESCRIPTION
http://www.dwheeler.com/essays/floss-license-slide.html refers to AGPL 3.0, not AGPL 1.0, so I think that references to AGPL 1.0 should be changed to refer to AGPL 3.0 instead.