### PR TITLE
Support licences separated by " OR "

### DIFF
--- a/src/license.rs
+++ b/src/license.rs
@@ -143,8 +143,9 @@ impl FromStr for License {
             "GPL-3.0+"           => License::GPL_3_0Plus,
             "AGPL-3.0"           => License::AGPL_3_0,
             "AGPL-3.0+"          => License::AGPL_3_0Plus,
-            s if s.contains('/') => {
+            s if s.contains('/') || s.contains(" OR ") => {
                 let mut licenses = s.split('/')
+                    .flat_map(|s| s.split(" OR "))
                     .map(str::parse)
                     .map(Result::unwrap)
                     .collect::<Vec<License>>();


### PR DESCRIPTION
Sometimes multi-license projects use `" OR "` to separate multiple licences (I believe this syntax is particularly widespread since there once was a bot which used it, submitting PR's to Rust projects "upgrading" them for either MIT or Apache 2.0 to a dual license).
