### PR TITLE
GPL table

### DIFF
--- a/src/license.rs
+++ b/src/license.rs
@@ -97,8 +97,9 @@ impl License {
         if let LGPL_2_0 = *other { return None; /* TODO: unknown */ }
 
         // GPL compatibility from https://www.gnu.org/licenses/gpl-faq.html#AllCompatibility
-        // The fields where combination would be upgraded to GPLv3
-        // are not considered.
+        // If the combined license would be different than both constituents,
+        // the licenses still are marked compatible.
+        // However, that change of license is not taken into account for the whole project.
         // The license on the left is "I want to license my code under".
         compatibility!(*self, *other, {
             Unspecified         => [Unlicense, MIT, X11, BSD_2_Clause, BSD_3_Clause]
@@ -113,11 +114,11 @@ impl License {
             Apache_2_0   => [Unlicense, MIT, X11, BSD_2_Clause, BSD_3_Clause, Apache_2_0]
             MPL_1_1      => [Unlicense, MIT, X11, BSD_2_Clause, BSD_3_Clause, MPL_1_1]
             MPL_2_0      => [Unlicense, MIT, X11, BSD_2_Clause, BSD_3_Clause, Apache_2_0, MPL_2_0]
-            LGPL_2_1Plus => [Unlicense, MIT, X11, BSD_2_Clause, BSD_3_Clause, MPL_2_0, LGPL_2_1Plus, LGPL_2_1, LGPL_3_0]
-            LGPL_2_1     => [Unlicense, MIT, X11, BSD_2_Clause, BSD_3_Clause, MPL_2_0, LGPL_2_1Plus, LGPL_2_1, LGPL_3_0]
-            LGPL_3_0Plus => [Unlicense, MIT, X11, BSD_2_Clause, BSD_3_Clause, MPL_2_0, Apache_2_0, LGPL_2_1Plus, LGPL_3_0Plus]
-            LGPL_3_0     => [Unlicense, MIT, X11, BSD_2_Clause, BSD_3_Clause, MPL_2_0, Apache_2_0, LGPL_2_1Plus, LGPL_2_1, LGPL_3_0Plus, LGPL_3_0]
-            GPL_2_0Plus  => [Unlicense, MIT, X11, BSD_2_Clause, BSD_3_Clause, MPL_2_0, LGPL_2_1Plus, LGPL_2_1, GPL_2_0Plus]
+            LGPL_2_1Plus => [Unlicense, MIT, X11, BSD_2_Clause, BSD_3_Clause, MPL_2_0, LGPL_2_1Plus, LGPL_2_1, LGPL_3_0, GPL_2_0, GPL_2_0Plus, GPL_3_0, AGPL_3_0]
+            LGPL_2_1     => [Unlicense, MIT, X11, BSD_2_Clause, BSD_3_Clause, MPL_2_0, LGPL_2_1Plus, LGPL_2_1, LGPL_3_0, GPL_2_0, GPL_2_0Plus, GPL_3_0, AGPL_3_0]
+            LGPL_3_0Plus => [Unlicense, MIT, X11, BSD_2_Clause, BSD_3_Clause, MPL_2_0, Apache_2_0, LGPL_2_1Plus, LGPL_3_0Plus, GPL_2_0Plus, GPL_3_0, AGPL_3_0]
+            LGPL_3_0     => [Unlicense, MIT, X11, BSD_2_Clause, BSD_3_Clause, MPL_2_0, Apache_2_0, LGPL_2_1Plus, LGPL_2_1, LGPL_3_0Plus, LGPL_3_0, GPL_2_0Plus, GPL_3_0, AGPL_3_0]
+            GPL_2_0Plus  => [Unlicense, MIT, X11, BSD_2_Clause, BSD_3_Clause, MPL_2_0, LGPL_2_1Plus, LGPL_2_1, LGPL_3_0, GPL_2_0Plus, GPL_3_0, AGPL_3_0]
             GPL_2_0      => [Unlicense, MIT, X11, BSD_2_Clause, BSD_3_Clause, MPL_2_0, LGPL_2_1Plus, LGPL_2_1, GPL_2_0Plus, GPL_2_0]
             GPL_3_0Plus  => [Unlicense, MIT, X11, BSD_2_Clause, BSD_3_Clause, MPL_2_0, Apache_2_0, LGPL_2_1Plus, LGPL_2_1, LGPL_3_0Plus, LGPL_3_0, GPL_2_0Plus, GPL_3_0Plus, GPL_3_0, AGPL_3_0]
             GPL_3_0      => [Unlicense, MIT, X11, BSD_2_Clause, BSD_3_Clause, MPL_2_0, Apache_2_0, LGPL_2_1Plus, LGPL_2_1, GPL_2_0Plus, GPL_3_0Plus, GPL_3_0]

--- a/src/license.rs
+++ b/src/license.rs
@@ -96,6 +96,10 @@ impl License {
         if let LGPL_2_0 = *self { return None; /* TODO: unknown */ }
         if let LGPL_2_0 = *other { return None; /* TODO: unknown */ }
 
+        // GPL compatibility from https://www.gnu.org/licenses/gpl-faq.html#AllCompatibility
+        // The fields where combination would be upgraded to GPLv3
+        // are not considered.
+        // The license on the left is "I want to license my code under".
         compatibility!(*self, *other, {
             Unspecified         => [Unlicense, MIT, X11, BSD_2_Clause, BSD_3_Clause]
 
@@ -109,15 +113,15 @@ impl License {
             Apache_2_0   => [Unlicense, MIT, X11, BSD_2_Clause, BSD_3_Clause, Apache_2_0]
             MPL_1_1      => [Unlicense, MIT, X11, BSD_2_Clause, BSD_3_Clause, MPL_1_1]
             MPL_2_0      => [Unlicense, MIT, X11, BSD_2_Clause, BSD_3_Clause, Apache_2_0, MPL_2_0]
-            LGPL_2_1Plus => [Unlicense, MIT, X11, BSD_2_Clause, BSD_3_Clause, MPL_2_0, LGPL_2_1Plus]
-            LGPL_2_1     => [Unlicense, MIT, X11, BSD_2_Clause, BSD_3_Clause, MPL_2_0, LGPL_2_1Plus, LGPL_2_1]
+            LGPL_2_1Plus => [Unlicense, MIT, X11, BSD_2_Clause, BSD_3_Clause, MPL_2_0, LGPL_2_1Plus, LGPL_2_1, LGPL_3_0]
+            LGPL_2_1     => [Unlicense, MIT, X11, BSD_2_Clause, BSD_3_Clause, MPL_2_0, LGPL_2_1Plus, LGPL_2_1, LGPL_3_0]
             LGPL_3_0Plus => [Unlicense, MIT, X11, BSD_2_Clause, BSD_3_Clause, MPL_2_0, Apache_2_0, LGPL_2_1Plus, LGPL_3_0Plus]
-            LGPL_3_0     => [Unlicense, MIT, X11, BSD_2_Clause, BSD_3_Clause, MPL_2_0, Apache_2_0, LGPL_2_1Plus, LGPL_3_0Plus, LGPL_3_0]
+            LGPL_3_0     => [Unlicense, MIT, X11, BSD_2_Clause, BSD_3_Clause, MPL_2_0, Apache_2_0, LGPL_2_1Plus, LGPL_2_1, LGPL_3_0Plus, LGPL_3_0]
             GPL_2_0Plus  => [Unlicense, MIT, X11, BSD_2_Clause, BSD_3_Clause, MPL_2_0, LGPL_2_1Plus, LGPL_2_1, GPL_2_0Plus]
             GPL_2_0      => [Unlicense, MIT, X11, BSD_2_Clause, BSD_3_Clause, MPL_2_0, LGPL_2_1Plus, LGPL_2_1, GPL_2_0Plus, GPL_2_0]
-            GPL_3_0Plus  => [Unlicense, MIT, X11, BSD_2_Clause, BSD_3_Clause, MPL_2_0, Apache_2_0, LGPL_2_1Plus, LGPL_2_1, GPL_2_0Plus, GPL_3_0Plus]
+            GPL_3_0Plus  => [Unlicense, MIT, X11, BSD_2_Clause, BSD_3_Clause, MPL_2_0, Apache_2_0, LGPL_2_1Plus, LGPL_2_1, LGPL_3_0Plus, LGPL_3_0, GPL_2_0Plus, GPL_3_0Plus, GPL_3_0, AGPL_3_0]
             GPL_3_0      => [Unlicense, MIT, X11, BSD_2_Clause, BSD_3_Clause, MPL_2_0, Apache_2_0, LGPL_2_1Plus, LGPL_2_1, GPL_2_0Plus, GPL_3_0Plus, GPL_3_0]
-            AGPL_3_0Plus => [Unlicense, MIT, X11, BSD_2_Clause, BSD_3_Clause, MPL_2_0, Apache_2_0, LGPL_2_1Plus, LGPL_2_1, GPL_2_0Plus, GPL_3_0Plus, GPL_3_0, AGPL_3_0Plus]
+            AGPL_3_0Plus => [Unlicense, MIT, X11, BSD_2_Clause, BSD_3_Clause, MPL_2_0, Apache_2_0, LGPL_2_1Plus, LGPL_2_1, LGPL_3_0Plus, LGPL_3_0, GPL_2_0Plus, GPL_3_0Plus, GPL_3_0, AGPL_3_0Plus]
             AGPL_3_0     => [Unlicense, MIT, X11, BSD_2_Clause, BSD_3_Clause, MPL_2_0, Apache_2_0, LGPL_2_1Plus, LGPL_2_1, GPL_2_0Plus, GPL_3_0Plus, GPL_3_0, AGPL_3_0Plus, AGPL_3_0]
 
             // TODO: These are `unreachable!()`, can't figure out a nice way to allow this in the macro...


### PR DESCRIPTION
Hi!

Thanks for the awesome license checker, this is something I dearly feel is missing in the Rust ecosystem. The way crates.io is structured is suited for permissive licenses, but not so much for respecting copyleft licenses. Here's a GPL table that will hopefully help with that.

The one resource I used is https://www.gnu.org/licenses/gpl-faq.html#AllCompatibility, usage explained in the comments. I limited myself to diligently copying the entries, without going into "or later". The second commit may cause somewhat misleading situations, as there's no way to represent a license upgrade at the moment. I thought it's still useful to have.