### PR TITLE
Fixed README markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# cargo-lichking [![travis-badge][]][travis] ![crate-badge][]][crate] [![license-badge][]][license] [![rust-version-badge][]][rust-version]
+# cargo-lichking [![travis-badge][]][travis] [![crate-badge][]][crate] [![license-badge][]][license] [![rust-version-badge][]][rust-version]
 
 Automated **li**cense **ch**ec**king** for rust. `cargo lichking` is a [Cargo][]
 subcommand that checks licensing information for dependencies.


### PR DESCRIPTION
I noticed there was a giant `]` in the rendered README and felt the need to fix it.

This fix makes it look like this:
![image](https://user-images.githubusercontent.com/1163510/70092728-c6741300-15d3-11ea-958b-2d3a1aa3fae7.png)

Rather than:
![image](https://user-images.githubusercontent.com/1163510/70092814-f4f1ee00-15d3-11ea-80ed-26d99163ffff.png)
Thanks,